### PR TITLE
Add ember-cli-autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "0.2.5",
     "ember-cli-app-version": "0.3.3",
+    "ember-cli-autoprefixer": "0.4.1",
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-htmlbars": "0.7.6",
     "ember-cli-ic-ajax": "0.1.1",


### PR DESCRIPTION
Fixes #5

It is possible to support more browsers.  By default, if I'm reading the notes correctly, this is necessary prefixes for the last 2 versions of any browser with more than 1% browser market share.  This seems sufficient.