### PR TITLE
Update to new helper API

### DIFF
--- a/addon/helpers/formatted-date.js
+++ b/addon/helpers/formatted-date.js
@@ -14,4 +14,4 @@ export function formattedDate(params, hash = {}) {
   return output;
 }
 
-export default Ember.HTMLBars.makeBoundHelper(formattedDate);
+export default Ember.Helper.helper(formattedDate);


### PR DESCRIPTION
Ember.HTMLBars.makeBoundHelper is deprecated in favor of
Ember.Helper.helper