### PR TITLE
Specify hours in a day instead of calculating them

### DIFF
--- a/addon/models/day.js
+++ b/addon/models/day.js
@@ -23,12 +23,12 @@ let Day = Ember.Object.extend({
 
   hours: Ember.computed('_momentDate', function() {
     let hours = Ember.A();
-    let startOfDayMoment = moment(this.get('_momentDate')).startOf('day');
+    let momentDate = this.get('_momentDate').clone();
 
     for (let i = 0; i < 24; i++) {
-      let datetime = moment(startOfDayMoment).toDate();
+      momentDate.hour(i);
+      let datetime = momentDate.toDate();
       let hour = Hour.create({ datetime: datetime, eventList: this.eventList });
-      startOfDayMoment.add(1, 'hours');
       hours.pushObject(hour);
     }
     return hours;

--- a/tests/unit/models/day-test.js
+++ b/tests/unit/models/day-test.js
@@ -34,3 +34,21 @@ test('Day#get("dayName") returns the correct day name', function(assert) {
   assert.equal(sunday.get('dayName'), 'Sunday');
   assert.equal(thursday.get('dayName'), 'Thursday');
 });
+
+test('Day#get("hours") returns the correct hours on DST start day', function (assert) {
+  let eventList = EventList.create({ events: Ember.A() });
+  let day = Day.create({ date: '2016-11-06', eventList: eventList });
+
+  assert.equal(day.get('hours.firstObject.formattedHour'), "12:00 am");
+  assert.equal(day.get('hours.lastObject.formattedHour'), "11:00 pm");
+  assert.equal(day.get('hours.length'), 24);
+});
+
+test('Day#get("hours") returns the correct hours on DST end day', function (assert) {
+  let eventList = EventList.create({ events: Ember.A() });
+  let day = Day.create({ date: '2016-03-13', eventList: eventList });
+
+  assert.equal(day.get('hours.firstObject.formattedHour'), "12:00 am");
+  assert.equal(day.get('hours.lastObject.formattedHour'), "11:00 pm");
+  assert.equal(day.get('hours.length'), 24);
+});


### PR DESCRIPTION
If we attempt to add each hour to a day by calculating it we end up with
two 1am slots on DST Sundays.  This throws off the day and week view of
the calendar.

Fixes #19